### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled command line

### DIFF
--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
+import java.util.HashMap;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -19,6 +21,16 @@ import java.util.logging.Logger;
 public class DemoApplication {
 	
 	private static final Logger LOGGER = Logger.getLogger(DemoApplication.class.getName());
+
+	// Allowlist of permitted commands
+	private static final Map<String, String[]> ALLOWED_COMMANDS = new HashMap<>();
+	static {
+		// Map user-friendly command names to actual system commands
+		ALLOWED_COMMANDS.put("date", new String[] {"date"});
+		ALLOWED_COMMANDS.put("uptime", new String[] {"uptime"});
+		ALLOWED_COMMANDS.put("whoami", new String[] {"whoami"});
+		// Add more allowed commands as needed
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(DemoApplication.class, args);
@@ -59,8 +71,12 @@ public class DemoApplication {
 	@GetMapping("/execute")
 	public String executeCommand(@RequestParam String command) {
 		try {
-			// VULNERABLE: Direct use of user input in system commands
-			Process process = Runtime.getRuntime().exec(command);
+			// Only allow execution of predefined commands
+			String[] cmd = ALLOWED_COMMANDS.get(command);
+			if (cmd == null) {
+				return "Error: Command not allowed";
+			}
+			Process process = Runtime.getRuntime().exec(cmd);
 			return "Command executed with exit code: " + process.waitFor();
 		} catch (IOException | InterruptedException e) {
 			return "Error: " + e.getMessage();


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/dmib-spring-boot-test/security/code-scanning/4](https://github.com/equinor/dmib-spring-boot-test/security/code-scanning/4)

To fix this vulnerability, the code should not allow arbitrary user input to be executed as a system command. The best approach is to restrict the set of commands that can be executed to a predefined, hard-coded list of safe commands. Instead of executing whatever the user provides, the code should check the user input against this list and only execute the corresponding command if it matches. This can be done by mapping user-friendly command names (e.g., "date", "uptime") to their actual system commands, and rejecting any input that does not match the allowed set.

Specifically, in `src/main/java/com/example/demo/DemoApplication.java`, in the `executeCommand` method (lines 60-68), replace the direct execution of the user-provided `command` with a lookup in a map of allowed commands. Only execute the command if it is in the allowed list; otherwise, return an error message.

You will need to:
- Import `java.util.Map` and `java.util.HashMap` if not already present.
- Define a static map of allowed commands.
- Change the method to look up the user input in the map and execute only if allowed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
